### PR TITLE
VTUL/EzidDOI#4: Change EDIT and STATUS links to use registered DOI in case of change to article metadata after registration.

### DIFF
--- a/EzidRegisterPlugin.inc.php
+++ b/EzidRegisterPlugin.inc.php
@@ -24,7 +24,7 @@ import('lib.pkp.classes.webservice.WebService');
 define('EZID_API_RESPONSE_CREATED', 201);
 define('EZID_API_RESPONSE_OK', 200);
 define('EZID_API_MINT_URL', 'https://ezid.cdlib.org/shoulder/doi:');
-define('EZID_API_MODIFY_URL', 'https://ezid.cdlib.org/id/doi:');
+define('EZID_API_CRUD_URL', 'https://ezid.cdlib.org/id/doi:');
 
 class EzidRegisterPlugin extends DOIExportPlugin {
 
@@ -318,10 +318,9 @@ class EzidRegisterPlugin extends DOIExportPlugin {
       $input .= "datacite.publicationyear: " . date('Y', strtotime($object->getDatePublished())) . PHP_EOL;
       $input .= "datacite.resourcetype: " . $object->getLocalizedData('type'). PHP_EOL;  
       if ($object->getData('ezid::registeredDoi')) {
-        $webServiceRequest = new WebServiceRequest(EZID_API_MODIFY_URL . $object->getStoredPubId('doi'), $input, 'POST');
+        $webServiceRequest = new WebServiceRequest(EZID_API_CRUD_URL . $object->getData('ezid::registeredDoi'), $input, 'POST');
         $expectedResponse = EZID_API_RESPONSE_OK;
-      }
-      else {
+      } else {
         $webServiceRequest = new WebServiceRequest(EZID_API_MINT_URL . $shoulder, $input, 'POST');
         $expectedResponse = EZID_API_RESPONSE_CREATED;
       }

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -21,7 +21,7 @@
   <message key="plugins.importexport.ezid.error.publisherNotConfigured"><![CDATA[A journal publisher has not been configured! You must add a publisher institution under <a href="{$publisherUrl}" target="_blank">Journal Setup Step 1.5</a>.]]></message>
   <message key="plugins.importexport.ezid.error.issnNotConfigured"><![CDATA[Journal Online ISSN has not been configured! You must apply one and add it under <a href="{$issnUrl}" target="_blank">Journal Setup Step 1.1</a>.]]></message>
   <message key="plugins.importexport.ezid.settings.depositorIntro">The following items are required for a successful ezid deposit.</message>
-  
+  <message key="plugins.importexport.ezid.doiMismatch">The registered DOI does not match the current article DOI of {$storedDoi}.</message>
 
   
   <message key="plugins.importexport.ezid.settings.form.automaticRegistration">Register DOIs automatically</message>

--- a/templates/articles.tpl
+++ b/templates/articles.tpl
@@ -68,7 +68,10 @@
           </nobr></td>
           <td align="center">
             {if $article->getData('ezid::registeredDoi')}
-              <a href="http://dx.doi.org/{$article->getStoredPubId('doi')|escape}" target="_blank">doi:{$article->getStoredPubId('doi')|escape}</a>
+              <a href="http://dx.doi.org/{$article->getData('ezid::registeredDoi')|escape}" target="_blank">doi:{$article->getData('ezid::registeredDoi')|escape}</a>
+              {if $article->getData('ezid::registeredDoi') != $article->getStoredPubId('doi')}
+                {translate key="plugins.importexport.ezid.doiMismatch" storedDoi=$article->getStoredPubId('doi')}
+              {/if}
             {else}
               -
             {/if}


### PR DESCRIPTION
Don't allow a manual change of the article's DOI to break the registration links and functionality of EZID.  Resolves https://github.com/VTUL/EzidDOI/issues/4

As a convenience, display a message to the user when such a mis-match occurs.

Also, change the EZID_API_MODIFY_URL constant name to better reflect that this URL can be used for full CRUD operations.  (This will be useful later.)
