### PR TITLE
VTUL/EzidDOI#15: Fix extraction of shadow ark in event of POST updates

### DIFF
--- a/EzidRegisterPlugin.inc.php
+++ b/EzidRegisterPlugin.inc.php
@@ -352,8 +352,14 @@ class EzidRegisterPlugin extends DOIExportPlugin {
     if ($result === true) {
       # trim off "success: doi:"
       $trimmed_body = preg_replace('/(success: doi:)/', '', $response);
-      list($doi, $ark) = explode(' ', $trimmed_body, 2);
-      
+      if (strstr($trimmed_body, ' | ark:') !== FALSE) {
+        list($doi, $ark) = explode(' | ark:', $trimmed_body, 2);
+        $ark = 'ark:'.$ark;
+      } else {
+        $doi = $trimmed_body;
+        $ark = '';
+      }
+
       if (is_a($object, 'Issue')) {
         $dao =& DAORegistry::getDAO('IssueDAO');
         $dao->changePubId($object->getId(), 'doi', $doi);


### PR DESCRIPTION
If the DOI is being created the response is `success: doi:$doi | ark:$ark`.

If the DOI is being updated, the response is `success: doi:$doi`.

While we are not using the ARK at this time, I'm going to assume we want it prefixed with 'ark:' to follow [the spec](www.cdlib.org/services/uc3/arkspec.pdf).  This will be easy enough to change later if we only want the characters after "ark:", like our strategy with the DOI currently.
