### PR TITLE
VTUL/EzidDOI#21: Do not change text case of DOI on registration

### DIFF
--- a/EzidRegisterPlugin.inc.php
+++ b/EzidRegisterPlugin.inc.php
@@ -362,13 +362,14 @@ class EzidRegisterPlugin extends DOIExportPlugin {
 
       if (is_a($object, 'Issue')) {
         $dao =& DAORegistry::getDAO('IssueDAO');
-        $dao->changePubId($object->getId(), 'doi', $doi);
-        $object->setStoredPubId('doi', $doi);
       } elseif (is_a($object, 'Article')) {
         $dao =& DAORegistry::getDAO('ArticleDAO');
-        $dao->changePubId($object->getId(), 'doi', $doi);
-        $object->setStoredPubId('doi', $doi);
       } 
+      $dao->changePubId($object->getId(), 'doi', $doi);
+      // Update the stored pub id if the change is not just text case
+      if (strtoupper($object->getStoredPubId('doi')) !== $doi) {
+        $object->setStoredPubId('doi', $doi);
+      }
       // Mark the object as registered.
       $this->markRegistered($request, $object, $shoulder);
     }

--- a/templates/articles.tpl
+++ b/templates/articles.tpl
@@ -69,7 +69,7 @@
           <td align="center">
             {if $article->getData('ezid::registeredDoi')}
               <a href="http://dx.doi.org/{$article->getData('ezid::registeredDoi')|escape}" target="_blank">doi:{$article->getData('ezid::registeredDoi')|escape}</a>
-              {if $article->getData('ezid::registeredDoi') != $article->getStoredPubId('doi')}
+              {if strtoupper($article->getData('ezid::registeredDoi')) != strtoupper($article->getStoredPubId('doi'))}
                 {translate key="plugins.importexport.ezid.doiMismatch" storedDoi=$article->getStoredPubId('doi')}
               {/if}
             {else}


### PR DESCRIPTION
Fixes https://github.com/VTUL/EzidDOI/issues/21.

Record the DOI as returned from EZID as the registered DOI.  Leave the stored DOI on the object alone if only text case is changing.

Bypass doiMismatch warning if a case insensitive match.
