### PR TITLE
VTUL/EzidDOI#26: Ensure DOIs can be minted if shoulder is set

### DIFF
--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -23,7 +23,7 @@
   <message key="plugins.importexport.ezid.error.webserviceNoResponse">No response from server.</message>
   <message key="plugins.importexport.ezid.error.webserviceInvalidRequest">An invalid webservice request was generated.</message>
   <message key="plugins.importexport.ezid.settings.depositorIntro">The following items are required for a successful ezid deposit.</message>
-  <message key="plugins.importexport.ezid.doiMismatch">The registered DOI does not match the current article DOI of {$storedDoi}.</message>
+  <message key="plugins.importexport.ezid.doiMismatch">The registered DOI does not match the current article DOI of "{$storedDoi}".</message>
 
   
   <message key="plugins.importexport.ezid.settings.form.automaticRegistration">Register DOIs automatically</message>

--- a/templates/issues.tpl
+++ b/templates/issues.tpl
@@ -67,7 +67,10 @@
           </nobr></td>
           <td align="center">
             {if $issue->getData('ezid::registeredDoi')}
-              <a href="http://dx.doi.org/{$issue->getStoredPubId('doi')|escape}" target="_blank">doi:{$issue->getStoredPubId('doi')|escape}</a>
+              <a href="http://dx.doi.org/$issue->getData('ezid::registeredDoi')|escape}" target="_blank">doi:{$issue->getData('ezid::registeredDoi')|escape}</a>
+              {if strtoupper($issue->getData('ezid::registeredDoi')) != strtoupper($issue->getStoredPubId('doi'))}
+                {translate key="plugins.importexport.ezid.doiMismatch" storedDoi=$issue->getStoredPubId('doi')}
+              {/if}
             {else}
               -
             {/if}


### PR DESCRIPTION
Resolves https://github.com/VTUL/EzidDOI/issues/26

Also ensures only one doi_data element is passed to EZID and clarify DOI mismatch output with quotes.

Note that the addition of `EZIDRegisterPlugin::displayArticleList()` is temporary, waiting on https://github.com/pkp/ojs/pull/647

Also, there is probably a better long term solution for `EzidExportDom::_generateJournalIssueDom()` via an upstream change in PKP.
