### PR TITLE
VTUL/EzidDOI#36: Add galleys back in (supported by EZID 4.4)

### DIFF
--- a/classes/EzidExportDom.inc.php
+++ b/classes/EzidExportDom.inc.php
@@ -130,8 +130,7 @@ class EzidExportDom extends CrossRefExportDom {
 		if ($this->_allowed_doi === $DOI || ($this->_allowed_doi === NULL && $this->getPluginSetting('shoulder'))) {
 			// Not only is this the only allowed doi_data element, it can only occur once.
 			$this->_allowed_doi = '';
-			// Disallow galleys to prevent creation of the collection element
-			return parent::_generateDOIdataDom($doc, $DOI, $url, null);
+			return parent::_generateDOIdataDom(&$doc, $DOI, $url, $galleys);
 		}
 		return XMLCustomWriter::createComment($doc, '');
 	}
@@ -163,11 +162,8 @@ class EzidExportDom extends CrossRefExportDom {
 			XMLCustomWriter::createChildWithText($doc, $journalIssueNode, 'issue', $issue->getNumber());
 		}
 
-		// Contra CrossRefExportDom::_generateJournalIssueDom, we do not need a stored DOI
-		if ($issue->getDatePublished()) {
-			$issueDoiNode =& $this->_generateDOIdataDom($doc, $issue->getPubId('doi'), Request::url($journal->getPath(), 'issue', 'view', $issue->getBestIssueId($journal)));
-			XMLCustomWriter::appendChild($journalIssueNode, $issueDoiNode);
-		}
+		// Contra CrossRefExportDom::_generateJournalIssueDom, disallow a DOI here
+		// TODO: this would be better as: `$issue = parent::_generateJournalIssueDom; return $this->deleteDOINode($issue);`
 
 		return $journalIssueNode;
 	}


### PR DESCRIPTION
EZID schema 4.4 again allows the `collection` element under `doi_data`; we represent galleys with this element.  Crazy code workaround for `$this->allowed_doi` because in the future OJS might allow export of the DOIs for galleys to CrossRef, but we can't allow that in EZID.

Also improve issue node handling of DOI nodes (just skip it instead of outputting a comment).  Even better would be to call the parent and then remove the DOI node (but we can't guarantee access to XPath functions yet).