### PR TITLE
VTUL/EzidDOI#43: Add scheduled task support for registering newly published articles

### DIFF
--- a/EzidRegisterPlugin.inc.php
+++ b/EzidRegisterPlugin.inc.php
@@ -36,11 +36,11 @@ class EzidRegisterPlugin extends CrossRefExportPlugin {
   }
 
   /**
-   * Skip the Crossref register() method
+   * This will register the plugin (specifically, setup the crontab callback for acron)
    * @see PKPPlugin::register()
    */
   function register($category, $path) {
-    $success = DOIExportPlugin::register($category, $path);
+    $success = parent::register($category, $path);
     return $success;
   }
   //
@@ -435,9 +435,10 @@ class EzidRegisterPlugin extends CrossRefExportPlugin {
    * @return array|boolean
   */
   function canBeExported($foundObject, &$errors) {
-    $journal =& Request::getJournal();
-    $optionalDoi = (boolean) $this->getSetting($journal->getId(), 'shoulder');
     if (is_a($foundObject, 'Issue') || is_a($foundObject, 'PublishedArticle')) {
+      // Issues and PublishedArticles should have a getJournalId() method
+      $journalId = $foundObject->getJournalId();
+      $optionalDoi = (boolean) ($journalId && $this->getSetting($journalId, 'shoulder'));
       return !is_null($foundObject->getPubId('doi')) || $optionalDoi;
     }
     return false;

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -54,4 +54,5 @@
 
   <message key="plugins.importexport.ezid.update">Edit</message>
   <message key="plugins.importexport.ezid.updateDescription">Click this button to update the meta-data of this object with EZID. This only works if you successfully registered the object before!</message>
+  <message key="plugins.importexport.ezid.senderTask.name">EZID Automatic Registration Task</message>
 </locale>

--- a/scheduledTasks.xml
+++ b/scheduledTasks.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  * plugins/importexport/EzidDOI/scheduledTasks.xml
+  *
+  * Copyright (c) 2013-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * EZID Plugin Deposit
+  *
+  * This file describes the schedule task that will send deposits to EZID in the background.
+  *
+  -->
+
+<!DOCTYPE scheduled_tasks SYSTEM "../../../lib/pkp/dtd/scheduledTasks.dtd">
+
+<scheduled_tasks>
+	<task class="plugins.importexport.EzidDOI.EzidInfoSender">
+		<descr>Send DOI deposit to EZID server.</descr>
+		<frequency minute="0"/>
+	</task>
+</scheduled_tasks>


### PR DESCRIPTION
This aligns EzidInfoSender with the existing `ScheduledTask::executeActions()` method, and calls `registerObjects()` on each article in series, accumulating error messages to the scheduled task log.

The acron callback is reenabled via the parent (CrossRef) plugin call.

The journalId is queried from the object itself rather than the request, as the request may not have a journal context from cron's perspective.

A scheduledTasks xml file is added to hook EzidInfoSender.